### PR TITLE
removed extra snippet

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -12,6 +12,6 @@
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">
-    <div style="display: contents">%sveltekit.body%</div>
+    <div style="display: contents" data-nosnippet>%sveltekit.body%</div>
   </body>
 </html>


### PR DESCRIPTION
designated textual parts of an HTML page not to be used as a snippet.

- only meta description tag (should be) used as snippet